### PR TITLE
Make initial emacs implementation like the other

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-Snake
-=====
+# Snake
+Making the game snake in different programming languages.
+
+## The Game Loop
+Games always follow a similar pattern of: "while the game is not over"
+
+1. Render
+2. Get input
+3. Update the game
+
+This is often referred to as the "game loop". I wanted to write down
+my current thoughts on how the "game loop" should be structured and
+why:
+
+1. Render the game. We do this first since the initial game state
+   should be seen by the player.
+2. Sleep. Doing this right after the render phase gives the player a
+   maximum amount of time to see the current game state and respond to
+   it.
+3. Read input.
+4. Update the game state based on the input. This should be a "dumb"
+   action which doesn't deal with interaction of objects, it just
+   moves objects to a new state.
+5. Resolve interactions between objects.
+
+Originally I was thinking that somewhere before or after (1) you
+should try and resolve interactions between objects. My thinking was
+that the initial game state could have interactions that need
+resolving. But I think that just overcomplicates things. The intial
+configuration of the game state should be set up so there are
+initially no interactions.
+
+(4) and (5) will probably be meshed together but it is worth
+considering them separately as it can help when thinking about the
+problem.

--- a/emacs/snake-read-event.el
+++ b/emacs/snake-read-event.el
@@ -5,9 +5,11 @@
 ;;; Commentary:
 
 ;; It's worth noting that emacs already has a built in snake game (of
-;; course it does), I just felt like making my own. From my
-;; experimentation with making games/animations I've learned a couple
-;; things:
+;; course it does), I just felt like making my own. This is my less
+;; preferred version of snake that I made but I kept it since it
+;; handles input differently and thought it would be nice to keep a
+;; record of that lying around somehwere. From my experimentation with
+;; making games/animations I've learned a couple things:
 
 ;; 1. When elisp code is being executed any keys you press are ignored
 ;; unless you explicitly read them in your code. One exception to this
@@ -63,13 +65,11 @@
 
 (load-file "util.el")
 
-;; I originally said it in the go implementation but I've added one
-;; more note. I think the best structure for a game loop is:
-;; 1. Render (the initial game state should be drawn after all)
-;; 2. Sleep (gives the player time to see the game and respond to it's current state
-;; 3. Get input
-;; 4. Update the game state
-;; 5. After the game loop exits (presumably due to a win or loss) redraw the game so the "end" state of the game can be seen
+(defun lag13/snake-read-event-new-dir (old-dir new-dir)
+  (if (lag13/are-perpendicular old-dir new-dir)
+      new-dir
+    old-dir))
+
 (defun lag13/snake-read-event ()
   "Starts the game of snake."
   (interactive)
@@ -84,12 +84,12 @@
          (is-paused nil))
     (while (not (lag13/snake-game-is-over width height snake-body))
       (lag13/snake-draw-game width height snake-body food-pos score is-paused)
-      (let ((key (read-event nil nil 0.2)))
+      (let ((key (read-event nil nil 0.1)))
         (cond
-         ((eq key 'up) (setq direction '(0 . -1)))
-         ((eq key 'down) (setq direction '(0 . 1)))
-         ((eq key 'left) (setq direction '(-1 . 0)))
-         ((eq key 'right) (setq direction '(1 . 0)))
+         ((eq key 'up) (setq direction (lag13/snake-read-event-new-dir direction '(0 . -1))))
+         ((eq key 'down) (setq direction (lag13/snake-read-event-new-dir direction '(0 . 1))))
+         ((eq key 'left) (setq direction (lag13/snake-read-event-new-dir direction '(-1 . 0))))
+         ((eq key 'right) (setq direction (lag13/snake-read-event-new-dir direction '(1 . 0))))
          ((eq key ?p) (setq is-paused (not is-paused)))))
       (unless is-paused
         (let ((snake-new-head (lag13/add-cons-pair direction (car snake-body))))

--- a/emacs/snake.el
+++ b/emacs/snake.el
@@ -5,7 +5,8 @@
 ;;; Commentary:
 
 ;; A different implementation of snake where the key presses are
-;; defined as key mappings.
+;; defined as key mappings which I believe is the preferred way of
+;; making games (I like it more as well).
 
 (load-file "util.el")
 
@@ -42,37 +43,31 @@
       (car *lag13/snake-direction-queue*)
     *lag13/snake-direction*))
 
-(defun lag13/snake-was-vertical-dir ()
-  "Returns t if the previously entered direction was vertical."
-  (zerop (car (lag13/snake-previous-entered-direction))))
+(defun lag13/snake-add-direction-to-queue (dir)
+  "Adds a newly entered direction to the queue if the direction
+is valid."
+  (when (lag13/are-perpendicular dir (lag13/snake-previous-entered-direction))
+    (push dir *lag13/snake-direction-queue*)))
 
 (defun lag13/snake-move-left ()
   "Moves the snake to the left."
   (interactive)
-  (when (lag13/snake-was-vertical-dir)
-    (push '(-1 . 0) *lag13/snake-direction-queue*)))
+  (lag13/snake-add-direction-to-queue '(-1 . 0)))
 
 (defun lag13/snake-move-right ()
   "Moves the snake to the right."
   (interactive)
-  (when (lag13/snake-was-vertical-dir)
-    (push '(1 . 0) *lag13/snake-direction-queue*)))
-
-(defun lag13/snake-was-horizontal-dir ()
-  "Returns t if the previously entered direction was horizontal."
-  (zerop (cdr (lag13/snake-previous-entered-direction))))
+  (lag13/snake-add-direction-to-queue '(1 . 0)))
 
 (defun lag13/snake-move-up ()
   "Moves the snake to the up."
   (interactive)
-  (when (lag13/snake-was-horizontal-dir)
-    (push '(0 . -1) *lag13/snake-direction-queue*)))
+  (lag13/snake-add-direction-to-queue '(0 . -1)))
 
 (defun lag13/snake-move-down ()
   "Moves the snake to the down."
   (interactive)
-  (when (lag13/snake-was-horizontal-dir)
-    (push '(0 . 1) *lag13/snake-direction-queue*)))
+  (lag13/snake-add-direction-to-queue '(0 . 1)))
 
 (defun lag13/snake-pause ()
   "Pauses the game."

--- a/emacs/util.el
+++ b/emacs/util.el
@@ -2,6 +2,13 @@
 ;;; snake which work a little differently but this code can still be
 ;;; shared.
 
+(defun lag13/are-perpendicular (v1 v2)
+  "Returns t if V1 and V2 are perpendicular to one another.
+According to linear algebra, two vectors are orthogonal if their
+dot product is 0."
+  (zerop (+ (* (car v1) (car v2))
+	    (* (cdr v1) (cdr v2)))))
+
 (defun lag13/intersperse (i lst)
   "Intersperse a value I into the list LST."
   (if (cdr lst)
@@ -98,4 +105,3 @@ character is drawn if it is off of the grid."
       (if (lag13/snake-won width height snake-body)
           (insert "Holy shit you won!!")
         (insert "You lost. Then again one usually \"loses\" at snake")))))
-    


### PR DESCRIPTION
I had made my second (and preferred) emacs implementation discard any
input that would make the snake go opposite its current direction. I
went back and did this for the initial implementation as well.

Also added a README description of how I think a game loop should be
structured.